### PR TITLE
Introducing the method to resend the last OTP SMS into the interface

### DIFF
--- a/src/OtpSmsProviderInterface.php
+++ b/src/OtpSmsProviderInterface.php
@@ -28,4 +28,16 @@ interface OtpSmsProviderInterface {
    */
   public function sendOtpSms(AccountInterface $user);
 
+  /**
+   * Resend the last OTP SMS to a user.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   Resend the last OTP SMS to this user.
+   *
+   * @throws \LogicException
+   *   Thrown if the user has never been sent an OTP SMS before, i.e. there is
+   *   no "last OTP SMS" to resend.
+   */
+  public function resendLastOtpSms(AccountInterface $user);
+
 }


### PR DESCRIPTION
We are having another custom module on top your OTP SMS where we do the "last mile" of 2FA tailored to our specific business needs.

Part of such "last mile" stuff is the "resend the SMS" button. This button is supposed to send a new text message with the **same** OTP password. We sure could do this in our custom module, but it felt just so natural to place it into the otp_sms module that I couldn't resist from filing this PR :) 

I hope you'll like it :) 